### PR TITLE
add volatile for asm.fix bugs in o2 optimize .

### DIFF
--- a/firmware/armv6/mmu.c
+++ b/firmware/armv6/mmu.c
@@ -253,16 +253,16 @@ void mmu_setttbase(register rt_uint32_t i)
 	 * set by page table entry
 	 */
 	value = 0;
-	asm ("mcr p15, 0, %0, c8, c7, 0"::"r"(value));
+	asm volatile ("mcr p15, 0, %0, c8, c7, 0"::"r"(value));
 
 	value = 0x55555555;
-	asm ("mcr p15, 0, %0, c3, c0, 0"::"r"(value));
-	asm ("mcr p15, 0, %0, c2, c0, 0"::"r"(i));
+	asm volatile ("mcr p15, 0, %0, c3, c0, 0"::"r"(value));
+	asm volatile ("mcr p15, 0, %0, c2, c0, 0"::"r"(i));
 }
 
 void mmu_set_domain(register rt_uint32_t i)
 {
-	asm ("mcr p15,0, %0, c3, c0,  0": :"r" (i));
+	asm volatile ("mcr p15,0, %0, c3, c0,  0": :"r" (i));
 }
 
 void mmu_enable()
@@ -270,7 +270,7 @@ void mmu_enable()
 	register rt_uint32_t i;
 
 	/* read control register */
-	asm ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
+	asm volatile ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
 
 	i |= 0x1;
 	/* Enables the extended page tables to be configured for
@@ -279,7 +279,7 @@ void mmu_enable()
 	i |= (1 << 13); /* High exception vectors selected, address range = 0xFFFF0000-0xFFFF001C */
 
 	/* write back to control register */
-	asm ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
+	asm volatile ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
 }
 
 void mmu_disable()
@@ -287,12 +287,12 @@ void mmu_disable()
 	register rt_uint32_t i;
 
 	/* read control register */
-	asm ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
+	asm volatile ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
 
 	i &= ~0x1;
 
 	/* write back to control register */
-	asm ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
+	asm volatile ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
 }
 
 void mmu_enable_icache()
@@ -300,12 +300,12 @@ void mmu_enable_icache()
 	register rt_uint32_t i;
 
 	/* read control register */
-	asm ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
+	asm volatile ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
 
 	i |= (1 << 12);
 
 	/* write back to control register */
-	asm ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
+	asm volatile ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
 }
 
 void mmu_enable_dcache()
@@ -313,12 +313,12 @@ void mmu_enable_dcache()
 	register rt_uint32_t i;
 
 	/* read control register */
-	asm ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
+	asm volatile ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
 
 	i |= (1 << 2);
 
 	/* write back to control register */
-	asm ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
+	asm volatile ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
 }
 
 void mmu_disable_icache()
@@ -326,12 +326,12 @@ void mmu_disable_icache()
 	register rt_uint32_t i;
 
 	/* read control register */
-	asm ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
+	asm volatile ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
 
 	i &= ~(1 << 12);
 
 	/* write back to control register */
-	asm ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
+	asm volatile ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
 }
 
 void mmu_disable_dcache()
@@ -339,12 +339,12 @@ void mmu_disable_dcache()
 	register rt_uint32_t i;
 
 	/* read control register */
-	asm ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
+	asm volatile ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
 
 	i &= ~(1 << 2);
 
 	/* write back to control register */
-	asm ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
+	asm volatile ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
 }
 
 void mmu_enable_alignfault()
@@ -352,12 +352,12 @@ void mmu_enable_alignfault()
 	register rt_uint32_t i;
 
 	/* read control register */
-	asm ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
+	asm volatile ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
 
 	i |= (1 << 1);
 
 	/* write back to control register */
-	asm ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
+	asm volatile ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
 }
 
 void mmu_disable_alignfault()
@@ -365,17 +365,17 @@ void mmu_disable_alignfault()
 	register rt_uint32_t i;
 
 	/* read control register */
-	asm ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
+	asm volatile ("mrc p15, 0, %0, c1, c0, 0":"=r" (i));
 
 	i &= ~(1 << 1);
 
 	/* write back to control register */
-	asm ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
+	asm volatile ("mcr p15, 0, %0, c1, c0, 0": :"r" (i));
 }
 
 void mmu_clean_invalidated_cache_index(int index)
 {
-	asm ("mcr p15, 0, %0, c7, c14, 2": :"r" (index));
+	asm volatile ("mcr p15, 0, %0, c7, c14, 2": :"r" (index));
 }
 
 void mmu_clean_invalidated_dcache(rt_uint32_t buffer, rt_uint32_t size)
@@ -386,7 +386,7 @@ void mmu_clean_invalidated_dcache(rt_uint32_t buffer, rt_uint32_t size)
 
 	while(ptr < buffer + size)
 	{
-		asm ("mcr p15, 0, %0, c7, c14, 1": :"r" (ptr));
+		asm volatile ("mcr p15, 0, %0, c7, c14, 1": :"r" (ptr));
 		ptr += CACHE_LINE_SIZE;
 	}
 }
@@ -400,7 +400,7 @@ void mmu_clean_dcache(rt_uint32_t buffer, rt_uint32_t size)
 
 	while (ptr < buffer + size)
 	{
-		asm ("mcr p15, 0, %0, c7, c10, 1": :"r" (ptr));
+		asm volatile ("mcr p15, 0, %0, c7, c10, 1": :"r" (ptr));
 		ptr += CACHE_LINE_SIZE;
 	}
 }
@@ -413,24 +413,24 @@ void mmu_invalidate_dcache(rt_uint32_t buffer, rt_uint32_t size)
 
 	while (ptr < buffer + size)
 	{
-		asm ("mcr p15, 0, %0, c7, c6, 1": :"r" (ptr));
+		asm volatile ("mcr p15, 0, %0, c7, c6, 1": :"r" (ptr));
 		ptr += CACHE_LINE_SIZE;
 	}
 }
 
 void mmu_invalidate_tlb()
 {
-	asm ("mcr p15, 0, %0, c8, c7, 0": :"r" (0));
+	asm volatile ("mcr p15, 0, %0, c8, c7, 0": :"r" (0));
 }
 
 void mmu_invalidate_icache()
 {
-	asm ("mcr p15, 0, %0, c7, c5, 0": :"r" (0));
+	asm volatile ("mcr p15, 0, %0, c7, c5, 0": :"r" (0));
 }
 
 void mmu_invalidate_dcache_all()
 {
-	asm ("mcr p15, 0, %0, c7, c6, 0": :"r" (0));
+	asm volatile ("mcr p15, 0, %0, c7, c6, 0": :"r" (0));
 }
 #endif
 


### PR DESCRIPTION
在O2优化等级下会优化在开启mmu时的程序流程，使程序读写寄存器没有遵循读改写的流程，一次读取多次修改，导致程序出错。添加volatile 保证每次修改之前进行寄存器读写。